### PR TITLE
Save BrewingBarrelTileEntity state

### DIFF
--- a/src/main/java/enemeez/simplefarming/tileentity/BrewingBarrelTileEntity.java
+++ b/src/main/java/enemeez/simplefarming/tileentity/BrewingBarrelTileEntity.java
@@ -32,6 +32,7 @@ public class BrewingBarrelTileEntity extends TileEntity implements IClearable {
 	public void clear() {
 		this.setItem(ItemStack.EMPTY.getItem());
 		capacity = 0;
+		this.markDirty();
 	}
 
 	public int getCapacity() {

--- a/src/main/java/enemeez/simplefarming/tileentity/BrewingBarrelTileEntity.java
+++ b/src/main/java/enemeez/simplefarming/tileentity/BrewingBarrelTileEntity.java
@@ -5,7 +5,10 @@ import static enemeez.simplefarming.init.ModTiles.BARREL_TILE;
 import net.minecraft.inventory.IClearable;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.registries.ForgeRegistries;
 
 public class BrewingBarrelTileEntity extends TileEntity implements IClearable {
 
@@ -33,5 +36,26 @@ public class BrewingBarrelTileEntity extends TileEntity implements IClearable {
 
 	public int getCapacity() {
 		return capacity;
+	}
+	
+	@Override
+	public void read(CompoundNBT compound) {
+		super.read(compound);
+		if(compound.contains("capacity")) {
+			capacity = compound.getInt("capacity");
+		}
+		if(compound.contains("inventory")) {
+			inventory = ForgeRegistries.ITEMS.getValue(new ResourceLocation(compound.getString("inventory")));
+		}
+		if(inventory == null) {
+			inventory = ItemStack.EMPTY.getItem();
+		}
+	}
+	
+	@Override
+	public CompoundNBT write(CompoundNBT compound) {
+		compound.putInt("capacity", capacity);
+		compound.putString("inventory", inventory.getRegistryName().toString());
+		return super.write(compound);
 	}
 }


### PR DESCRIPTION
This PR fixes #74 by saving the `capacity` and `inventory` values from the `BrewingBarrelTileEntity` when the TE gets saved.