### PR TITLE
Make brewing data driven

### DIFF
--- a/src/main/java/enemeez/simplefarming/block/BrewingBarrelBlock.java
+++ b/src/main/java/enemeez/simplefarming/block/BrewingBarrelBlock.java
@@ -80,11 +80,11 @@ public class BrewingBarrelBlock extends ContainerBlock {
 	}
 
 	@Override
-	public ActionResultType onBlockActivated(BlockState state, World worldIn, BlockPos pos, PlayerEntity player,
+	public ActionResultType func_225533_a_(BlockState state, World worldIn, BlockPos pos, PlayerEntity player,
 			Hand handIn, BlockRayTraceResult hit) {
 		TileEntity tileentity = worldIn.getTileEntity(pos);
 		if (tileentity instanceof BrewingBarrelTileEntity) {
-			if (player.isShiftKeyDown()) {
+			if (player.func_225608_bj_()) {
 				if (getLayers(state) == 1 && getProgress(state) == 0) {
 					this.dropItem(worldIn, pos);
 					state = state.with(LAYERS, Integer.valueOf(0));
@@ -157,9 +157,9 @@ public class BrewingBarrelBlock extends ContainerBlock {
 
 	@Override
 	@SuppressWarnings("deprecation")
-	public void tick(BlockState state, ServerWorld worldIn, BlockPos pos, Random random) {
+	public void func_225534_a_(BlockState state, ServerWorld worldIn, BlockPos pos, Random random) {
 		if (this.readyToFerment(state)) {
-			super.tick(state, worldIn, pos, random);
+			super.func_225534_a_(state, worldIn, pos, random);
 			int i = state.get(PROGRESS);
 			if (i < 3 && random.nextInt(5) == 0) {
 				worldIn.setBlockState(pos,

--- a/src/main/java/enemeez/simplefarming/init/ModRecipes.java
+++ b/src/main/java/enemeez/simplefarming/init/ModRecipes.java
@@ -1,0 +1,33 @@
+package enemeez.simplefarming.init;
+
+import enemeez.simplefarming.SimpleFarming;
+import enemeez.simplefarming.integration.BrewingBarrelRecipe;
+import enemeez.simplefarming.integration.BrewingBarrelRecipeSerializer;
+import net.minecraft.item.crafting.IRecipeSerializer;
+import net.minecraft.item.crafting.IRecipeType;
+import net.minecraft.util.registry.Registry;
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.registries.ObjectHolder;
+
+@Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.MOD)
+public class ModRecipes {
+	
+	@ObjectHolder("simplefarming:brewing")
+	public static BrewingBarrelRecipeSerializer BREWING_BARREL_RECIPE_SERIALIZER;
+	
+	public static IRecipeType<BrewingBarrelRecipe> BREWING_BARREL_RECIPE_TYPE;
+
+	@SubscribeEvent
+	public static void onRecipeSerializerRegistry(RegistryEvent.Register<IRecipeSerializer<?>> event) {
+		event.getRegistry().register(new BrewingBarrelRecipeSerializer().setRegistryName(SimpleFarming.getId("brewing")));
+		
+		BREWING_BARREL_RECIPE_TYPE = Registry.register(Registry.RECIPE_TYPE, SimpleFarming.getId("brewing"), new IRecipeType<BrewingBarrelRecipe>() {
+			@Override
+	        public String toString() {
+	            return SimpleFarming.getId("brewing").toString();
+	        }
+		});
+	}
+}

--- a/src/main/java/enemeez/simplefarming/integration/BrewingBarrelRecipe.java
+++ b/src/main/java/enemeez/simplefarming/integration/BrewingBarrelRecipe.java
@@ -1,0 +1,70 @@
+package enemeez.simplefarming.integration;
+
+import enemeez.simplefarming.init.ModRecipes;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.item.crafting.IRecipeSerializer;
+import net.minecraft.item.crafting.IRecipeType;
+import net.minecraft.item.crafting.Ingredient;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.world.World;
+
+public class BrewingBarrelRecipe implements IRecipe<IInventory> {
+	
+	private final ResourceLocation id;
+	private final ItemStack result;
+	private final Ingredient ingredient;
+	
+	public BrewingBarrelRecipe(ResourceLocation id, Ingredient ingredient, ItemStack result) {
+		this.id = id;
+		this.ingredient = ingredient;
+		this.result = result;
+	}
+	
+	public Ingredient getIngredient() {
+		return ingredient;
+	}
+
+	@Override
+	public boolean matches(IInventory inv, World worldIn) {
+		return ingredient.test(inv.getStackInSlot(0));
+	}
+
+	@Override
+	public ItemStack getCraftingResult(IInventory inv) {
+		return result.copy();
+	}
+
+	@Override
+	public boolean canFit(int width, int height) {
+		return true;
+	}
+
+	@Override
+	public ItemStack getRecipeOutput() {
+		return ItemStack.EMPTY;
+	}
+
+	@Override
+	public ResourceLocation getId() {
+		return id;
+	}
+	
+	//Disable RecipeBook for this recipe
+	@Override
+	public boolean isDynamic() {
+		return true;
+	}
+	
+	@Override
+	public IRecipeSerializer<?> getSerializer() {
+		return ModRecipes.BREWING_BARREL_RECIPE_SERIALIZER;
+	}
+
+	@Override
+	public IRecipeType<?> getType() {
+		return ModRecipes.BREWING_BARREL_RECIPE_TYPE;
+	}
+
+}

--- a/src/main/java/enemeez/simplefarming/integration/BrewingBarrelRecipeSerializer.java
+++ b/src/main/java/enemeez/simplefarming/integration/BrewingBarrelRecipeSerializer.java
@@ -1,0 +1,37 @@
+package enemeez.simplefarming.integration;
+
+import com.google.gson.JsonObject;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.IRecipeSerializer;
+import net.minecraft.item.crafting.Ingredient;
+import net.minecraft.network.PacketBuffer;
+import net.minecraft.util.JSONUtils;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.common.crafting.CraftingHelper;
+import net.minecraftforge.registries.ForgeRegistryEntry;
+
+public class BrewingBarrelRecipeSerializer extends ForgeRegistryEntry<IRecipeSerializer<?>> implements IRecipeSerializer<BrewingBarrelRecipe> {
+
+	@Override
+	public BrewingBarrelRecipe read(ResourceLocation recipeId, JsonObject json) {
+		JsonObject ingredientJson = JSONUtils.getJsonObject(json, "ingredient");
+		Ingredient ingredient = Ingredient.deserialize(ingredientJson);
+		ItemStack result = CraftingHelper.getItemStack(JSONUtils.getJsonObject(json, "result"), false);
+		return new BrewingBarrelRecipe(recipeId, ingredient, result);
+	}
+
+	@Override
+	public BrewingBarrelRecipe read(ResourceLocation recipeId, PacketBuffer buffer) {
+		Ingredient ingredient = Ingredient.read(buffer);
+		ItemStack result = buffer.readItemStack();
+		return new BrewingBarrelRecipe(recipeId, ingredient, result);
+	}
+
+	@Override
+	public void write(PacketBuffer buffer, BrewingBarrelRecipe recipe) {
+		recipe.getIngredient().write(buffer);
+		buffer.writeItemStack(recipe.getCraftingResult(null));
+	}
+
+}

--- a/src/main/resources/data/simplefarming/recipes/brewing_beer.json
+++ b/src/main/resources/data/simplefarming/recipes/brewing_beer.json
@@ -1,0 +1,9 @@
+{
+    "type": "simplefarming:brewing",
+    "ingredient": {
+        "item": "simplefarming:barley"
+    },
+    "result": {
+        "item": "simplefarming:beer"
+    }
+}

--- a/src/main/resources/data/simplefarming/recipes/brewing_cauim.json
+++ b/src/main/resources/data/simplefarming/recipes/brewing_cauim.json
@@ -1,0 +1,9 @@
+{
+    "type": "simplefarming:brewing",
+    "ingredient": {
+        "item": "simplefarming:cassava"
+    },
+    "result": {
+        "item": "simplefarming:cauim"
+    }
+}

--- a/src/main/resources/data/simplefarming/recipes/brewing_cider.json
+++ b/src/main/resources/data/simplefarming/recipes/brewing_cider.json
@@ -1,0 +1,9 @@
+{
+    "type": "simplefarming:brewing",
+    "ingredient": {
+        "item": "minecraft:apple"
+    },
+    "result": {
+        "item": "simplefarming:cider"
+    }
+}

--- a/src/main/resources/data/simplefarming/recipes/brewing_sake.json
+++ b/src/main/resources/data/simplefarming/recipes/brewing_sake.json
@@ -1,0 +1,9 @@
+{
+    "type": "simplefarming:brewing",
+    "ingredient": {
+        "item": "simplefarming:rice"
+    },
+    "result": {
+        "item": "simplefarming:sake"
+    }
+}

--- a/src/main/resources/data/simplefarming/recipes/brewing_tiswin.json
+++ b/src/main/resources/data/simplefarming/recipes/brewing_tiswin.json
@@ -1,0 +1,9 @@
+{
+    "type": "simplefarming:brewing",
+    "ingredient": {
+        "item": "simplefarming:cactus_fruit"
+    },
+    "result": {
+        "item": "simplefarming:tiswin"
+    }
+}

--- a/src/main/resources/data/simplefarming/recipes/brewing_vodka.json
+++ b/src/main/resources/data/simplefarming/recipes/brewing_vodka.json
@@ -1,0 +1,9 @@
+{
+    "type": "simplefarming:brewing",
+    "ingredient": {
+        "item": "minecraft:potato"
+    },
+    "result": {
+        "item": "simplefarming:vodka"
+    }
+}

--- a/src/main/resources/data/simplefarming/recipes/brewing_whiskey.json
+++ b/src/main/resources/data/simplefarming/recipes/brewing_whiskey.json
@@ -1,0 +1,9 @@
+{
+    "type": "simplefarming:brewing",
+    "ingredient": {
+        "item": "minecraft:wheat"
+    },
+    "result": {
+        "item": "simplefarming:whiskey"
+    }
+}

--- a/src/main/resources/data/simplefarming/recipes/brewing_wine.json
+++ b/src/main/resources/data/simplefarming/recipes/brewing_wine.json
@@ -1,0 +1,9 @@
+{
+    "type": "simplefarming:brewing",
+    "ingredient": {
+        "item": "simplefarming:grapes"
+    },
+    "result": {
+        "item": "simplefarming:wine"
+    }
+}


### PR DESCRIPTION
This PR moves the hard coded brewing recipes to a data driven system, where all recipes are defined by JSON files.
The recipe files are located in `data/simplefarming/recipes/` and contain an `ingredient` entry for the input (e.g. `simplefarming:grapes`) and a `result` entry for the output (e.g. `simplefarming:wine`)

closes #75