### PR TITLE
Fix conflict with More Waterlogging

### DIFF
--- a/src/main/java/enemeez/simplefarming/block/growable/FruitLeavesBlock.java
+++ b/src/main/java/enemeez/simplefarming/block/growable/FruitLeavesBlock.java
@@ -91,7 +91,8 @@ public class FruitLeavesBlock extends LeavesBlock implements IGrowable {
 	}
 
 	protected void fillStateContainer(StateContainer.Builder<Block, BlockState> builder) {
-		builder.add(DISTANCE, PERSISTENT, AGE);
+		super.fillStateContainer(builder);
+		builder.add(AGE);
 	}
 
 	public IntegerProperty getAgeProperty() {


### PR DESCRIPTION
This fixes an issue caused by overriding the builder and not calling super as More Waterlogging uses that to make more blocks waterloggable.

This change will allow the fruit leaves to be waterlogged.