### PR TITLE
[1.20] Fix datapack issues

### DIFF
--- a/src/main/resources/data/simplefarming/recipes/netherite_scythe_smithing.json
+++ b/src/main/resources/data/simplefarming/recipes/netherite_scythe_smithing.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:smithing",
+  "type": "minecraft:smithing_transform",
   "addition": {
     "item": "minecraft:netherite_ingot"
   },
@@ -8,5 +8,8 @@
   },
   "result": {
     "item": "simplefarming:netherite_scythe"
+  },
+  "template": {
+    "item": "minecraft:netherite_upgrade_smithing_template"
   }
 }

--- a/src/main/resources/data/simplefarming/tags/blocks/mineable/scythe.json
+++ b/src/main/resources/data/simplefarming/tags/blocks/mineable/scythe.json
@@ -4,6 +4,6 @@
     "#minecraft:flowers",
     "#minecraft:crops",
     "#minecraft:saplings",
-    "#minecraft:replaceable_plants"
+    "#minecraft:replaceable_by_trees"
   ]
 }


### PR DESCRIPTION
This PR fixes two datapack issues in the current version:

1. Mojang removed the `replaceable_plants` tag in 23w14a in favor of the `replaceable_by_trees` tag. I replaced the reference to the tag in the simplefarming `blocks/mineable/scythe` tag.
2. Mojang changed the `minecraft:smithing` recipe type to `minecraft:smithing_transform`. I updated the simplefarming netherite_scythe_smithing recepe accordingly.