### PR TITLE
[1.20] Add JEI support for the fermenter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -151,14 +151,14 @@ repositories {
     //     dir 'libs'
     // }
     maven {
-    	// location of the maven that hosts JEI files since January 2023
-    	name = "Jared's maven"
-    	url = "https://maven.blamejared.com/"
+        // location of the maven that hosts JEI files since January 2023
+        name = "Jared's maven"
+        url = "https://maven.blamejared.com/"
   	}
   	maven {
-    	// location of a maven mirror for JEI files, as a fallback
-    	name = "ModMaven"
-    	url = "https://modmaven.dev"
+        // location of a maven mirror for JEI files, as a fallback
+        name = "ModMaven"
+        url = "https://modmaven.dev"
   	}
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -150,6 +150,16 @@ repositories {
     // flatDir {
     //     dir 'libs'
     // }
+    maven {
+    	// location of the maven that hosts JEI files since January 2023
+    	name = "Jared's maven"
+    	url = "https://maven.blamejared.com/"
+  	}
+  	maven {
+    	// location of a maven mirror for JEI files, as a fallback
+    	name = "ModMaven"
+    	url = "https://modmaven.dev"
+  	}
 }
 
 test {
@@ -164,6 +174,12 @@ dependencies {
     // that the dep is a ForgeGradle 'patcher' dependency, and its patches will be applied.
     // The userdev artifact is a special name and will get all sorts of transformations applied to it.
     minecraft 'net.minecraftforge:forge:1.20.1-47.0.43'
+    
+    // compile against the JEI API but do not include it at runtime
+    compileOnly(fg.deobf("mezz.jei:jei-1.20.1-common-api:15.2.0.23"))
+    compileOnly(fg.deobf("mezz.jei:jei-1.20.1-forge-api:15.2.0.23"))
+    // at runtime, use the full JEI jar for Forge
+    runtimeOnly(fg.deobf("mezz.jei:jei-1.20.1-forge:15.2.0.23"))
 
 
     // Real mod deobf dependency examples - these get remapped to your current mappings

--- a/src/main/java/enemeez/simplefarming/client/gui/FermenterScreen.java
+++ b/src/main/java/enemeez/simplefarming/client/gui/FermenterScreen.java
@@ -12,7 +12,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Inventory;
 
 public class FermenterScreen extends AbstractContainerScreen<FermenterMenu> {
-    private static final ResourceLocation TEXTURE = new ResourceLocation(SimpleFarming.MOD_ID, "textures/gui/fermenter.png");
+    public static final ResourceLocation TEXTURE = new ResourceLocation(SimpleFarming.MOD_ID, "textures/gui/fermenter.png");
 
     public FermenterScreen(FermenterMenu pMenu, Inventory pPlayerInventory, Component pTitle) {
         super(pMenu, pPlayerInventory, pTitle);

--- a/src/main/java/enemeez/simplefarming/client/integration/JeiIntegration.java
+++ b/src/main/java/enemeez/simplefarming/client/integration/JeiIntegration.java
@@ -4,8 +4,10 @@ import java.util.List;
 
 import enemeez.simplefarming.client.gui.FermenterScreen;
 import enemeez.simplefarming.common.SimpleFarming;
+import enemeez.simplefarming.common.block.menu.FermenterMenu;
 import enemeez.simplefarming.common.item.crafting.FermenterRecipe;
 import enemeez.simplefarming.common.registries.ModItems;
+import enemeez.simplefarming.common.registries.ModMenus;
 import mezz.jei.api.IModPlugin;
 import mezz.jei.api.JeiPlugin;
 import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
@@ -21,6 +23,7 @@ import mezz.jei.api.recipe.category.IRecipeCategory;
 import mezz.jei.api.registration.IRecipeCatalystRegistration;
 import mezz.jei.api.registration.IRecipeCategoryRegistration;
 import mezz.jei.api.registration.IRecipeRegistration;
+import mezz.jei.api.registration.IRecipeTransferRegistration;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.core.NonNullList;
@@ -56,6 +59,11 @@ public class JeiIntegration implements IModPlugin {
     @Override
     public void registerRecipeCatalysts(IRecipeCatalystRegistration registration) {
         registration.addRecipeCatalyst(new ItemStack(ModItems.FERMENTER.get()), FERMENTER_RECIPE_TYPE);
+    }
+    
+    @Override
+    public void registerRecipeTransferHandlers(IRecipeTransferRegistration registration) {
+        registration.addRecipeTransferHandler(FermenterMenu.class, ModMenus.FERMENTER_MENU.get(), FERMENTER_RECIPE_TYPE, 36, 2, 0, 36);
     }
     
     private static class FermenterCategory implements IRecipeCategory<FermenterRecipe> {

--- a/src/main/java/enemeez/simplefarming/client/integration/JeiIntegration.java
+++ b/src/main/java/enemeez/simplefarming/client/integration/JeiIntegration.java
@@ -1,0 +1,108 @@
+package enemeez.simplefarming.client.integration;
+
+import java.util.List;
+
+import enemeez.simplefarming.client.gui.FermenterScreen;
+import enemeez.simplefarming.common.SimpleFarming;
+import enemeez.simplefarming.common.item.crafting.FermenterRecipe;
+import enemeez.simplefarming.common.registries.ModItems;
+import mezz.jei.api.IModPlugin;
+import mezz.jei.api.JeiPlugin;
+import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
+import mezz.jei.api.gui.drawable.IDrawable;
+import mezz.jei.api.gui.drawable.IDrawableAnimated;
+import mezz.jei.api.gui.ingredient.IRecipeSlotsView;
+import mezz.jei.api.helpers.IGuiHelper;
+import mezz.jei.api.helpers.IJeiHelpers;
+import mezz.jei.api.recipe.IFocusGroup;
+import mezz.jei.api.recipe.RecipeIngredientRole;
+import mezz.jei.api.recipe.RecipeType;
+import mezz.jei.api.recipe.category.IRecipeCategory;
+import mezz.jei.api.registration.IRecipeCatalystRegistration;
+import mezz.jei.api.registration.IRecipeCategoryRegistration;
+import mezz.jei.api.registration.IRecipeRegistration;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.core.NonNullList;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.Ingredient;
+
+@JeiPlugin
+public class JeiIntegration implements IModPlugin {
+    
+    private static final RecipeType<FermenterRecipe> FERMENTER_RECIPE_TYPE = RecipeType.create(SimpleFarming.MOD_ID, FermenterRecipe.Type.ID, FermenterRecipe.class);
+
+    @Override
+    public ResourceLocation getPluginUid() {
+        return new ResourceLocation(SimpleFarming.MOD_ID, "jei");
+    }
+    
+    @Override
+    public void registerCategories(IRecipeCategoryRegistration registration) {
+        IJeiHelpers jeiHelpers = registration.getJeiHelpers();
+        IGuiHelper guiHelper = jeiHelpers.getGuiHelper();
+        registration.addRecipeCategories(new FermenterCategory(guiHelper));
+    }
+    
+    @SuppressWarnings("resource")
+    @Override
+    public void registerRecipes(IRecipeRegistration registration) {
+        List<FermenterRecipe> fermenterRecipies = Minecraft.getInstance().level.getRecipeManager().getAllRecipesFor(FermenterRecipe.Type.INSTANCE);
+        registration.addRecipes(FERMENTER_RECIPE_TYPE, fermenterRecipies);
+    }
+    
+    @Override
+    public void registerRecipeCatalysts(IRecipeCatalystRegistration registration) {
+        registration.addRecipeCatalyst(new ItemStack(ModItems.FERMENTER.get()), FERMENTER_RECIPE_TYPE);
+    }
+    
+    private static class FermenterCategory implements IRecipeCategory<FermenterRecipe> {
+        
+        private final IDrawableAnimated arrow;
+        private final IDrawable background;
+        private final IDrawable icon;
+        
+        public FermenterCategory(IGuiHelper guiHelper) {
+            arrow = guiHelper.drawableBuilder(FermenterScreen.TEXTURE, 176, 14, 24, 17).buildAnimated(200, IDrawableAnimated.StartDirection.LEFT, false);
+            background = guiHelper.createDrawable(FermenterScreen.TEXTURE, 51, 12, 90, 62);
+            icon = guiHelper.createDrawableItemStack(new ItemStack(ModItems.FERMENTER.get()));
+        }
+
+        @Override
+        public RecipeType<FermenterRecipe> getRecipeType() {
+            return FERMENTER_RECIPE_TYPE;
+        }
+
+        @Override
+        public Component getTitle() {
+            return Component.translatable("container.fermenter");
+        }
+
+        @Override
+        public IDrawable getBackground() {
+            return background;
+        }
+
+        @Override
+        public IDrawable getIcon() {
+            return icon;
+        }
+
+        @Override
+        public void setRecipe(IRecipeLayoutBuilder builder, FermenterRecipe recipe, IFocusGroup focuses) {
+            NonNullList<Ingredient> ingredients = recipe.getIngredients();
+            builder.addSlot(RecipeIngredientRole.INPUT, 5, 5).addIngredients(ingredients.get(0));
+            builder.addSlot(RecipeIngredientRole.INPUT, 5, 41).addIngredients(ingredients.get(1));
+            builder.addSlot(RecipeIngredientRole.OUTPUT, 65, 23).addItemStack(recipe.getResultItem(null));
+        }
+        
+        @Override
+        public void draw(FermenterRecipe recipe, IRecipeSlotsView recipeSlotsView, GuiGraphics guiGraphics, double mouseX, double mouseY) {
+            arrow.draw(guiGraphics, 28, 23);
+        }
+        
+    }
+
+}

--- a/src/main/java/enemeez/simplefarming/client/integration/JeiIntegration.java
+++ b/src/main/java/enemeez/simplefarming/client/integration/JeiIntegration.java
@@ -73,7 +73,7 @@ public class JeiIntegration implements IModPlugin {
         private final IDrawable icon;
         
         public FermenterCategory(IGuiHelper guiHelper) {
-            arrow = guiHelper.drawableBuilder(FermenterScreen.TEXTURE, 176, 14, 24, 17).buildAnimated(200, IDrawableAnimated.StartDirection.LEFT, false);
+            arrow = guiHelper.drawableBuilder(FermenterScreen.TEXTURE, 176, 14, 24, 17).buildAnimated(2000, IDrawableAnimated.StartDirection.LEFT, false);
             background = guiHelper.createDrawable(FermenterScreen.TEXTURE, 51, 12, 90, 62);
             icon = guiHelper.createDrawableItemStack(new ItemStack(ModItems.FERMENTER.get()));
         }

--- a/src/main/java/enemeez/simplefarming/common/data/ModWorldGenProvider.java
+++ b/src/main/java/enemeez/simplefarming/common/data/ModWorldGenProvider.java
@@ -13,7 +13,7 @@ import java.util.concurrent.CompletableFuture;
 
 public class ModWorldGenProvider extends DatapackBuiltinEntriesProvider {
     public static final RegistrySetBuilder BUILDER = new RegistrySetBuilder()
-        .add(Registries.CONFIGURED_FEATURE, b -> ModFeatures.bootstrap(b)) // ModFeatures::bootstrap
+        .add(Registries.CONFIGURED_FEATURE, ModFeatures::bootstrap)
         .add(Registries.PLACED_FEATURE, ModPlacements::bootstrap);
 
     public ModWorldGenProvider(PackOutput output, CompletableFuture<HolderLookup.Provider> registries, Set<String> modIds) {

--- a/src/main/java/enemeez/simplefarming/common/data/ModWorldGenProvider.java
+++ b/src/main/java/enemeez/simplefarming/common/data/ModWorldGenProvider.java
@@ -13,7 +13,7 @@ import java.util.concurrent.CompletableFuture;
 
 public class ModWorldGenProvider extends DatapackBuiltinEntriesProvider {
     public static final RegistrySetBuilder BUILDER = new RegistrySetBuilder()
-        .add(Registries.CONFIGURED_FEATURE, ModFeatures::bootstrap)
+        .add(Registries.CONFIGURED_FEATURE, b -> ModFeatures.bootstrap(b)) // ModFeatures::bootstrap
         .add(Registries.PLACED_FEATURE, ModPlacements::bootstrap);
 
     public ModWorldGenProvider(PackOutput output, CompletableFuture<HolderLookup.Provider> registries, Set<String> modIds) {

--- a/src/main/java/enemeez/simplefarming/common/item/crafting/FermenterRecipe.java
+++ b/src/main/java/enemeez/simplefarming/common/item/crafting/FermenterRecipe.java
@@ -1,12 +1,15 @@
 package enemeez.simplefarming.common.item.crafting;
 
 import com.google.gson.JsonObject;
+
+import net.minecraft.core.NonNullList;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.GsonHelper;
 import net.minecraft.world.Container;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.item.crafting.RecipeSerializer;
@@ -89,5 +92,13 @@ public class FermenterRecipe implements Recipe<Container> {
     @Override
     public RecipeType<?> getType() {
         return Type.INSTANCE;
+    }
+    
+    @Override
+    public NonNullList<Ingredient> getIngredients() {
+        NonNullList<Ingredient> ingredients = NonNullList.createWithCapacity(2);
+        ingredients.add(INGREDIENT);
+        ingredients.add(Ingredient.of(Items.GLASS_BOTTLE));
+        return ingredients;
     }
 }

--- a/src/main/java/enemeez/simplefarming/common/item/crafting/FermenterRecipe.java
+++ b/src/main/java/enemeez/simplefarming/common/item/crafting/FermenterRecipe.java
@@ -96,9 +96,6 @@ public class FermenterRecipe implements Recipe<Container> {
     
     @Override
     public NonNullList<Ingredient> getIngredients() {
-        NonNullList<Ingredient> ingredients = NonNullList.createWithCapacity(2);
-        ingredients.add(INGREDIENT);
-        ingredients.add(Ingredient.of(Items.GLASS_BOTTLE));
-        return ingredients;
+        return NonNullList.of(null, INGREDIENT, Ingredient.of(Items.GLASS_BOTTLE));
     }
 }


### PR DESCRIPTION
This PR adds JEI support for the fermenter recipes.

To get access to the ingredients in a FermenterRecipe I implemented the `Recipe#getIngredients` method. This currently causes some errors in the logs:
```
[Render thread/WARN] [net.minecraft.client.ClientRecipeBook/]: Unknown recipe category: [!!!com.mojang.logging.LogUtils$1ToString@639517ac=>java.lang.NullPointerException:Cannot invoke "Object.toString()" because the return value of "java.util.function.Supplier.get()" is null!!!]/simplefarming:cauim
[Render thread/WARN] [net.minecraft.client.ClientRecipeBook/]: Unknown recipe category: [!!!com.mojang.logging.LogUtils$1ToString@7f61ed7c=>java.lang.NullPointerException:Cannot invoke "Object.toString()" because the return value of "java.util.function.Supplier.get()" is null!!!]/simplefarming:vodka
[Render thread/WARN] [net.minecraft.client.ClientRecipeBook/]: Unknown recipe category: [!!!com.mojang.logging.LogUtils$1ToString@14741927=>java.lang.NullPointerException:Cannot invoke "Object.toString()" because the return value of "java.util.function.Supplier.get()" is null!!!]/simplefarming:whiskey
[Render thread/WARN] [net.minecraft.client.ClientRecipeBook/]: Unknown recipe category: [!!!com.mojang.logging.LogUtils$1ToString@72ed4e67=>java.lang.NullPointerException:Cannot invoke "Object.toString()" because the return value of "java.util.function.Supplier.get()" is null!!!]/simplefarming:tiswin
[Render thread/WARN] [net.minecraft.client.ClientRecipeBook/]: Unknown recipe category: [!!!com.mojang.logging.LogUtils$1ToString@7211ab39=>java.lang.NullPointerException:Cannot invoke "Object.toString()" because the return value of "java.util.function.Supplier.get()" is null!!!]/simplefarming:mead
[Render thread/WARN] [net.minecraft.client.ClientRecipeBook/]: Unknown recipe category: [!!!com.mojang.logging.LogUtils$1ToString@1c55db35=>java.lang.NullPointerException:Cannot invoke "Object.toString()" because the return value of "java.util.function.Supplier.get()" is null!!!]/simplefarming:beer
[Render thread/WARN] [net.minecraft.client.ClientRecipeBook/]: Unknown recipe category: [!!!com.mojang.logging.LogUtils$1ToString@4defc8ca=>java.lang.NullPointerException:Cannot invoke "Object.toString()" because the return value of "java.util.function.Supplier.get()" is null!!!]/simplefarming:cider
[Render thread/WARN] [net.minecraft.client.ClientRecipeBook/]: Unknown recipe category: [!!!com.mojang.logging.LogUtils$1ToString@342b545a=>java.lang.NullPointerException:Cannot invoke "Object.toString()" because the return value of "java.util.function.Supplier.get()" is null!!!]/simplefarming:wine
[Render thread/WARN] [net.minecraft.client.ClientRecipeBook/]: Unknown recipe category: [!!!com.mojang.logging.LogUtils$1ToString@2acc5a39=>java.lang.NullPointerException:Cannot invoke "Object.toString()" because the return value of "java.util.function.Supplier.get()" is null!!!]/simplefarming:sake
```
This is caused by the recipe book implementation which can't handle modded recipe types. It looks like its safe to ignore the warnings, but a possible solution is to either override `Recipe#isSpecial` to return true or use a diffrent method to get the ingredients of the recipe.
Do you want me to change the current behavior to something diffrent?